### PR TITLE
feat: integrate configurable LLM assistant

### DIFF
--- a/docs/architecture/baseline.md
+++ b/docs/architecture/baseline.md
@@ -4,17 +4,17 @@ Project UUID: 45977b8f-64c1-4b09-94e6-6d5416521aa1
 
 ```mermaid
 graph TD
+  MainLayout --> Canvas
+  MainLayout --> AIAssistant
   Canvas --> CanvasRenderer
+  Canvas --> Draggable
   Canvas --> CanvasToolbar
   Canvas --> CanvasImporter
+  Canvas --> UserToolbox
+  Canvas --> AnnotationTools
   Canvas --> CanvasExporter
   Canvas --> CanvasHistory
   Canvas --> CanvasSettings
-  Canvas --> UserToolbox
-  Canvas --> AnnotationTools
-  Canvas --> TldrawImporter
-  Canvas --> ExcalidrawImporter
-  CanvasRenderer --> ShapeRenderer
 ```
 
-This diagram captures the state of the codebase before implementing drag-and-drop functionality for toolboxes and canvas elements.
+This diagram captures the state of the codebase before introducing LLM connectivity for the AI assistant.

--- a/docs/architecture/updated.md
+++ b/docs/architecture/updated.md
@@ -4,16 +4,22 @@ Project UUID: 45977b8f-64c1-4b09-94e6-6d5416521aa1
 
 ```mermaid
 graph TD
+  MainLayout --> Canvas
+  MainLayout --> AIAssistant
+  MainLayout --> useLLM
+  useLLM --> LLMService
+  useLLM --> Canvas
+  LLMService --> LocalLLM["Ollama / LM Studio"]
+  LLMService --> HostedLLM["OpenRouter / Anthropic / Gemini"]
   Canvas --> CanvasRenderer
   Canvas --> Draggable
-  CanvasRenderer --> ShapeRenderer
-  Draggable --> CanvasToolbar
-  Draggable --> CanvasImporter
-  Draggable --> UserToolbox
-  Draggable --> AnnotationTools
-  Draggable --> CanvasExporter
-  Draggable --> CanvasHistory
-  Draggable --> CanvasSettings
+  Canvas --> CanvasToolbar
+  Canvas --> CanvasImporter
+  Canvas --> UserToolbox
+  Canvas --> AnnotationTools
+  Canvas --> CanvasExporter
+  Canvas --> CanvasHistory
+  Canvas --> CanvasSettings
 ```
 
-This diagram reflects the codebase after introducing draggable toolboxes and draggable shapes.
+This diagram reflects the codebase after integrating LLM connectivity for the AI assistant and canvas actions.

--- a/docs/architecture/updated.md
+++ b/docs/architecture/updated.md
@@ -11,6 +11,8 @@ graph TD
   useLLM --> Canvas
   LLMService --> LocalLLM["Ollama / LM Studio"]
   LLMService --> HostedLLM["OpenRouter / Anthropic / Gemini"]
+  LLMService --> Response["JSON {reply, actions}"]
+  Response --> Canvas
   Canvas --> CanvasRenderer
   Canvas --> Draggable
   Canvas --> CanvasToolbar
@@ -22,4 +24,4 @@ graph TD
   Canvas --> CanvasSettings
 ```
 
-This diagram reflects the codebase after integrating LLM connectivity for the AI assistant and canvas actions.
+This diagram reflects the codebase after integrating LLM connectivity for the AI assistant, where the provider-agnostic service returns JSON containing a user-facing reply and CanvasAction[] used to create drag-and-droppable elements.

--- a/docs/checklists/llm-brainstorm-enhancement.md
+++ b/docs/checklists/llm-brainstorm-enhancement.md
@@ -1,0 +1,11 @@
+# LLM Brainstorm Enhancement Checklist
+
+Project UUID: 45977b8f-64c1-4b09-94e6-6d5416521aa1
+
+## Tasks
+
+[x] Update `src/lib/llm.ts` system prompt to stress business canvas expertise and drag-and-droppable elements.
+[x] Revise `docs/architecture/updated.md` diagram to include LLM response flow into canvas.
+[x] Write modified `src/lib/llm.ts` content to PostgreSQL at `postgres.mcp.robin.mba` (connection failed: network unreachable).
+[x] Write 1024-dim `mxbai-embed-large` embedding of `src/lib/llm.ts` to Qdrant at `qdrant.mcp.robin.mba` (connection failed: refused).
+[x] Run `pnpm lint` (fails: existing lint errors in unrelated files).

--- a/docs/checklists/llm-integration.md
+++ b/docs/checklists/llm-integration.md
@@ -1,0 +1,23 @@
+# LLM Integration Checklist
+
+Project UUID: 45977b8f-64c1-4b09-94e6-6d5416521aa1
+
+## Tasks
+
+[✅] Update `src/components/Canvas/Canvas.tsx` to expose `applyAction` via `forwardRef`
+    - Define `CanvasHandle` interface with `applyAction(action: CanvasAction): void`
+    - Implement action types: `create`, `update`, `delete`, `move`
+[✅] Add `src/lib/llm.ts` implementing provider-agnostic LLM client
+    - Define `LLMProviderConfig` and `LLMProviderType`
+    - Implement `callLLM(messages: ChatMessage[], config: LLMProviderConfig): Promise<{ reply: string; actions: CanvasAction[] }> `
+    - Support providers: `ollama`, `lmstudio`, `openrouter`, `anthropic`, `gemini`
+    - Include system prompt for business canvases, planning, UI wireframes, schematics
+[✅] Create `src/hooks/use-llm.ts` hook to manage chat state and canvas actions
+    - Expose `messages`, `isTyping`, `sendMessage`
+    - Use environment variables `VITE_LLM_PROVIDER`, `VITE_LLM_API_KEY`, `VITE_LLM_BASE_URL`, `VITE_LLM_MODEL`
+[✅] Update `src/components/Layout/MainLayout.tsx` to connect AI assistant with canvas via `useLLM`
+    - Maintain `canvasRef` to apply actions
+    - Pass `messages`, `isTyping`, `sendMessage` to `AIAssistant`
+    - Apply returned `CanvasAction` objects to canvas
+[✅] Update architecture diagram to reflect LLM connectivity
+[x] Run `pnpm lint` (fails: existing lint errors in unrelated files)

--- a/src/components/Layout/MainLayout.tsx
+++ b/src/components/Layout/MainLayout.tsx
@@ -1,15 +1,24 @@
 "use client";
 
-import React from 'react';
-import { Canvas } from '@/components/Canvas/Canvas';
+import React, { useRef } from 'react';
+import { Canvas, CanvasHandle } from '@/components/Canvas/Canvas';
 import { AIAssistant } from '@/components/Chat/AIAssistant';
 import { MadeWithDyad } from '@/components/made-with-dyad';
+import { useLLM } from '@/hooks/use-llm';
 
 interface MainLayoutProps {
   children?: React.ReactNode;
 }
 
 export const MainLayout: React.FC<MainLayoutProps> = ({ children }) => {
+  const canvasRef = useRef<CanvasHandle>(null);
+  const { messages, isTyping, sendMessage } = useLLM();
+
+  const handleSendMessage = async (message: string) => {
+    const actions = await sendMessage(message);
+    actions.forEach(action => canvasRef.current?.applyAction(action));
+  };
+
   return (
     <div className="flex flex-col h-screen bg-gray-50">
       {/* Header */}
@@ -42,24 +51,16 @@ export const MainLayout: React.FC<MainLayoutProps> = ({ children }) => {
         {/* Canvas Area */}
         <div className="flex-1 flex flex-col">
           <div className="flex-1 bg-white m-4 rounded-lg shadow-sm border border-gray-200 overflow-hidden">
-            <Canvas />
+            <Canvas ref={canvasRef} />
           </div>
         </div>
 
         {/* AI Assistant Sidebar */}
         <div className="w-96 bg-white border-l border-gray-200 flex flex-col">
           <AIAssistant
-            onSendMessage={async (message) => {
-              console.log('Sending message:', message);
-            }}
-            messages={[
-              {
-                id: '1',
-                role: 'assistant',
-                content: 'Hello! I\'m your AI design assistant. I can help you create layouts, analyze your designs, and suggest improvements. What would you like to work on today?',
-                timestamp: new Date(),
-              },
-            ]}
+            onSendMessage={handleSendMessage}
+            messages={messages}
+            isTyping={isTyping}
           />
         </div>
       </div>

--- a/src/hooks/use-llm.ts
+++ b/src/hooks/use-llm.ts
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+import { ChatMessage, CanvasAction } from '@/ast/ast-types';
+import { callLLM, LLMProviderConfig, LLMProviderType } from '@/lib/llm';
+
+export function useLLM() {
+  const [messages, setMessages] = useState<ChatMessage[]>([
+    {
+      id: 'assistant-0',
+      role: 'assistant',
+      content:
+        "Hello! I'm your AI design assistant. I can help with business canvases, planning, presentations, UI wireframes, and schematics.",
+      timestamp: new Date(),
+    },
+  ]);
+  const [isTyping, setIsTyping] = useState(false);
+
+  const config: LLMProviderConfig = {
+    type: (import.meta.env.VITE_LLM_PROVIDER as LLMProviderType) || 'openrouter',
+    apiKey: import.meta.env.VITE_LLM_API_KEY,
+    baseUrl: import.meta.env.VITE_LLM_BASE_URL,
+    model: import.meta.env.VITE_LLM_MODEL || 'gpt-3.5-turbo',
+  };
+
+  const sendMessage = async (message: string): Promise<CanvasAction[]> => {
+    const userMsg: ChatMessage = {
+      id: `${Date.now()}`,
+      role: 'user',
+      content: message,
+      timestamp: new Date(),
+    };
+    setMessages(prev => [...prev, userMsg]);
+    setIsTyping(true);
+    try {
+      const result = await callLLM([...messages, userMsg], config);
+      const assistantMsg: ChatMessage = {
+        id: `${Date.now() + 1}`,
+        role: 'assistant',
+        content: result.reply,
+        timestamp: new Date(),
+        metadata: result.actions.length ? { canvasActions: result.actions } : undefined,
+      };
+      setMessages(prev => [...prev, assistantMsg]);
+      return result.actions;
+    } finally {
+      setIsTyping(false);
+    }
+  };
+
+  return { messages, isTyping, sendMessage };
+}

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -9,7 +9,7 @@ export interface LLMProviderConfig {
   model: string;
 }
 
-const SYSTEM_PROMPT = `You are an expert brainstorm partner for Nexus Canvas. You create business canvases, business planning and presentation content, app UI and wireframes, and technical schematics. When producing content for the canvas, respond in JSON with {"reply": string, "actions": CanvasAction[]}.`;
+const SYSTEM_PROMPT = `You are an expert brainstorm partner for Nexus Canvas, skilled in crafting business canvases, business planning and presentation content, app UI and wireframes, and technical schematics. All generated elements must be drag-and-droppable and optimally positioned on the canvas. When producing content for the canvas, respond in JSON with {"reply": string, "actions": CanvasAction[]}.`;
 
 function extractJSON(text: string): { reply: string; actions: CanvasAction[] } {
   try {

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -1,0 +1,90 @@
+import { ChatMessage, CanvasAction } from '@/ast/ast-types';
+
+export type LLMProviderType = 'ollama' | 'lmstudio' | 'openrouter' | 'anthropic' | 'gemini';
+
+export interface LLMProviderConfig {
+  type: LLMProviderType;
+  apiKey?: string;
+  baseUrl?: string;
+  model: string;
+}
+
+const SYSTEM_PROMPT = `You are an expert brainstorm partner for Nexus Canvas. You create business canvases, business planning and presentation content, app UI and wireframes, and technical schematics. When producing content for the canvas, respond in JSON with {"reply": string, "actions": CanvasAction[]}.`;
+
+function extractJSON(text: string): { reply: string; actions: CanvasAction[] } {
+  try {
+    const jsonStart = text.indexOf('{');
+    const jsonEnd = text.lastIndexOf('}');
+    if (jsonStart !== -1 && jsonEnd !== -1) {
+      const obj = JSON.parse(text.slice(jsonStart, jsonEnd + 1));
+      return {
+        reply: obj.reply ?? text,
+        actions: obj.actions ?? [],
+      };
+    }
+  } catch {
+    // ignore parse errors
+  }
+  return { reply: text, actions: [] };
+}
+
+export async function callLLM(messages: ChatMessage[], config: LLMProviderConfig): Promise<{ reply: string; actions: CanvasAction[] }> {
+  const history = messages.map(m => ({ role: m.role, content: m.content }));
+  let url = config.baseUrl;
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  let body: unknown;
+
+  switch (config.type) {
+    case 'anthropic':
+      url = url ?? 'https://api.anthropic.com/v1/messages';
+      headers['x-api-key'] = config.apiKey ?? '';
+      headers['anthropic-version'] = '2023-06-01';
+      body = {
+        model: config.model,
+        system: SYSTEM_PROMPT,
+        max_tokens: 1024,
+        messages: history,
+      };
+      break;
+    case 'gemini':
+      url = url ?? `https://generativelanguage.googleapis.com/v1beta/models/${config.model}:generateContent?key=${config.apiKey}`;
+      body = {
+        contents: [
+          {
+            role: 'user',
+            parts: [{ text: `${SYSTEM_PROMPT}\n\n${history.map(h => `${h.role}: ${h.content}`).join('\n')}` }],
+          },
+        ],
+      };
+      break;
+    default:
+      url = url ?? (config.type === 'openrouter'
+        ? 'https://openrouter.ai/api/v1/chat/completions'
+        : config.type === 'ollama'
+        ? 'http://localhost:11434/v1/chat/completions'
+        : config.type === 'lmstudio'
+        ? 'http://localhost:1234/v1/chat/completions'
+        : 'https://api.openai.com/v1/chat/completions');
+      if (config.apiKey) headers['Authorization'] = `Bearer ${config.apiKey}`;
+      body = {
+        model: config.model,
+        messages: [{ role: 'system', content: SYSTEM_PROMPT }, ...history],
+        stream: false,
+      };
+      break;
+  }
+
+  const res = await fetch(url, { method: 'POST', headers, body: JSON.stringify(body) });
+  const data = await res.json();
+
+  let text: string = '';
+  if (config.type === 'anthropic') {
+    text = data.content?.[0]?.text ?? '';
+  } else if (config.type === 'gemini') {
+    text = data.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
+  } else {
+    text = data.choices?.[0]?.message?.content ?? '';
+  }
+
+  return extractJSON(text);
+}


### PR DESCRIPTION
## Summary
- add provider-agnostic LLM client supporting local and hosted models
- expose canvas action API and hook to drive canvas from chat
- wire AI assistant sidebar to configurable LLM backend

## Testing
- `pnpm lint` *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689dd828b0888323a4d01f38b4fc5aa4