### PR TITLE
docs: expand readme with license

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
-# Welcome to your Dyad app
+# TLLMDraw
+
+An interactive drawing canvas powered by [tldraw](https://tldraw.dev/) and enhanced with an AI assistant. Built with Vite, React, TypeScript, and ShadCN UI components.
+
+## Features
+- Real-time canvas for sketches, annotations, and prototypes.
+- AI assistant capable of generating and manipulating canvas elements via large language models.
+- Responsive UI with theme support.
+
+## Getting Started
+
+### Prerequisites
+- Node.js >= 18
+- [pnpm](https://pnpm.io/)
+
+### Installation
+```bash
+pnpm install
+```
+
+### Development
+```bash
+pnpm dev
+```
+
+### Build
+```bash
+pnpm build
+```
+
+### Lint
+```bash
+pnpm lint
+```
+
+## License
+Copyright (C)2025 Robin L. M. Cheung, MBA. All rights reserved.
+
+This project incorporates open-source libraries that retain their respective licenses.
+
+## Organization
+Robin L. M. Cheung
+
+Contact: [tllmdraw@RobinsAI.World](mailto:tllmdraw@RobinsAI.World)

--- a/docs/architecture/readme-license.md
+++ b/docs/architecture/readme-license.md
@@ -1,0 +1,27 @@
+# Project Architecture - README & License Update
+
+Project UUID: 45977b8f-64c1-4b09-94e6-6d5416521aa1
+
+```mermaid
+graph TD
+  MainLayout --> Canvas
+  MainLayout --> AIAssistant
+  MainLayout --> useLLM
+  useLLM --> LLMService
+  useLLM --> Canvas
+  LLMService --> LocalLLM["Ollama / LM Studio"]
+  LLMService --> HostedLLM["OpenRouter / Anthropic / Gemini"]
+  LLMService --> Response["JSON {reply, actions}"]
+  Response --> Canvas
+  Canvas --> CanvasRenderer
+  Canvas --> Draggable
+  Canvas --> CanvasToolbar
+  Canvas --> CanvasImporter
+  Canvas --> UserToolbox
+  Canvas --> AnnotationTools
+  Canvas --> CanvasExporter
+  Canvas --> CanvasHistory
+  Canvas --> CanvasSettings
+```
+
+Architecture unchanged for README & license update.

--- a/docs/checklists/readme-license.md
+++ b/docs/checklists/readme-license.md
@@ -1,0 +1,8 @@
+# README and License Update Checklist
+
+- ✅ Create `docs/architecture/readme-license.md` with current project UUID and existing component diagram.
+- ✅ Expand `README.md` with project overview, features, setup instructions, and licensing details including default copyright.
+- [ ] Run `pnpm lint` to ensure formatting and linting pass. *(fails: existing lint errors in unrelated files)*
+- [ ] Attempt to write architecture nodes and relationships to Neo4j using project UUID `45977b8f-64c1-4b09-94e6-6d5416521aa1`. *(connection refused)*
+- [ ] Attempt to store updated `README.md` content in Postgres tagged with the same UUID. *(connection refused)*
+- [ ] Attempt to embed `README.md` content with `mxbai-embed-large` and upsert into Qdrant collection keyed by the UUID. *(connection refused)*


### PR DESCRIPTION
## Summary
- document project setup, features, and licensing in a comprehensive README
- capture current architecture diagram for documentation changes
- track work in a detailed checklist including external system sync attempts

## Testing
- `pnpm lint` *(fails: Unexpected any, parsing errors, and other lint issues across src/ files)*

------
https://chatgpt.com/codex/tasks/task_e_689e6f7872b483238f906b301a77f392